### PR TITLE
Update classes and specs

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -97,14 +97,14 @@ router.get('/Teachers/:id', (req, res) => {
 });
 
 
-// Get Classes
-router.get('/Classes', (req, res) => {
+// Get Courses
+router.get('/Courses', (req, res) => {
     connection((db) => {
-        db.collection('Classes')
+        db.collection('Courses')
             .find()
             .toArray()
-            .then((Classes) => {
-                response.data = Classes;
+            .then((Courses) => {
+                response.data = Courses;
                 res.json(response);
             })
             .catch((err) => {
@@ -113,14 +113,14 @@ router.get('/Classes', (req, res) => {
     });
 });
 
-// Get ClassesID
-router.get('/Classes/:id', (req, res) => {
+// Get CoursesID
+router.get('/Courses/:id', (req, res) => {
     connection((db) => {
-        db.collection('Classes')
+        db.collection('Courses')
             .find({ "_id": ObjectID(req.params.id) })
             .toArray()
-            .then((ClassesID) => {
-                response.data = ClassesID;
+            .then((CoursesID) => {
+                response.data = CoursesID;
                 res.json(response);
             })
             .catch((err) => {

--- a/src/app/administrator/administrator.service.spec.ts
+++ b/src/app/administrator/administrator.service.spec.ts
@@ -6,11 +6,11 @@ import { AdministratorService } from './administrator.service';
 import { Administrator } from './administrator';
 
 export const ADMINISTRATORS: Administrator[] = [
-  { _id: 1, username: 'testuser1', course_ids: [1, 2, 3], review_ids: [1, 2, 3], student_ids: [1, 2, 3], teacher_ids: [1, 2, 3] },
-  { _id: 2, username: 'testuser2', course_ids: [6, 4, 15], review_ids: [4, 5, 6], student_ids: [1, 2, 3], teacher_ids: [1, 2, 3] },
-  { _id: 3, username: 'testuser3', course_ids: [5, 14, 13], review_ids: [7, 8, 9], student_ids: [1, 2, 3], teacher_ids: [1, 2, 3] },
-  { _id: 4, username: 'testuser4', course_ids: [12, 8, 7], review_ids: [10, 11, 12], student_ids: [1, 2, 3], teacher_ids: [1, 2, 3] },
-  { _id: 5, username: 'testuser5', course_ids: [10, 9, 11], review_ids: [13, 14, 15], student_ids: [1, 2, 3], teacher_ids: [1, 2, 3] },
+  { _id: 1, username: 'test_admin1', fullname: 'Test Admin1', teacher_ids: [1, 2, 3] },
+  { _id: 2, username: 'test_admin2', fullname: 'Test Admin2', teacher_ids: [1, 2, 3] },
+  { _id: 3, username: 'test_admin3', fullname: 'Test Admin3', teacher_ids: [1, 2, 3] },
+  { _id: 4, username: 'test_admin4', fullname: 'Test Admin4', teacher_ids: [1, 2, 3] },
+  { _id: 5, username: 'test_admin5', fullname: 'Test Admin5', teacher_ids: [1, 2, 3] },
 ];
 
 let mock_response_type;

--- a/src/app/administrator/administrator.ts
+++ b/src/app/administrator/administrator.ts
@@ -2,17 +2,13 @@
 export class Administrator {
     _id: number;
     username: string;
-    course_ids: number[];
-    review_ids: number[];
-    student_ids: number[];
+    fullname: string;
     teacher_ids: number[];
 
-    constructor(_id: number, username: string, course_ids: number[], review_ids: number[], student_ids: number[], teacher_ids: number[]) {
+    constructor(_id: number, fullname: string, username: string, teacher_ids: number[]) {
         this._id = _id;
+        this.fullname = fullname;
         this.username = username;
-        this.course_ids = course_ids;
-        this.review_ids = review_ids;
-        this.student_ids = student_ids;
         this.teacher_ids = teacher_ids;
     }
 }

--- a/src/app/course/course.service.spec.ts
+++ b/src/app/course/course.service.spec.ts
@@ -6,9 +6,9 @@ import { CourseService } from './course.service';
 import { Course } from './course';
 
 export const COURSES: Course[] = [
-  { _id: 1, courseName: "AAA1234", student_ids: [1, 2, 3], teacher_id: 1 },
-  { _id: 2, courseName: "BBB5678", student_ids: [1, 2, 3], teacher_id: 2 },
-  { _id: 3, courseName: "CCC0910", student_ids: [1, 2, 3], teacher_id: 3 },
+  { _id: 1, courseCode: 'AAA1234', courseName: 'Test Course1' },
+  { _id: 2, courseCode: 'BBB5678', courseName: 'Test Course2' },
+  { _id: 3, courseCode: 'CCC0910', courseName: 'Test Course3' },
 ];
 
 let mock_response_type;

--- a/src/app/course/course.ts
+++ b/src/app/course/course.ts
@@ -2,13 +2,11 @@
 export class Course {
     _id: number;
     courseName: string;
-    student_ids: number[];
-    teacher_id: number;
+    courseCode: string;
 
-    constructor(_id: number, courseName: string, student_ids: number[], teacher_id: number) {
+    constructor(_id: number, courseName: string, courseCode: string) {
         this._id = _id;
         this.courseName = courseName;
-        this.student_ids = student_ids;
-        this.teacher_id = teacher_id;
+        this.courseCode = courseCode;
     }
 }

--- a/src/app/student/student.service.spec.ts
+++ b/src/app/student/student.service.spec.ts
@@ -6,11 +6,11 @@ import { StudentService } from './student.service';
 import { Student } from './student';
 
 export const STUDENTS: Student[] = [
-  { _id: 1, username: 'testuser1', course_ids: [1, 2, 3], review_ids: [1, 2, 3] },
-  { _id: 2, username: 'testuser2', course_ids: [6, 4, 15], review_ids: [4, 5, 6] },
-  { _id: 3, username: 'testuser3', course_ids: [5, 14, 13], review_ids: [7, 8, 9] },
-  { _id: 4, username: 'testuser4', course_ids: [12, 8, 7], review_ids: [10, 11, 12] },
-  { _id: 5, username: 'testuser5', course_ids: [10, 9, 11], review_ids: [13, 14, 15] },
+  { _id: 1, username: 'test_student1', fullname: 'Test Student1' },
+  { _id: 2, username: 'test_student2', fullname: 'Test Student2' },
+  { _id: 3, username: 'test_student3', fullname: 'Test Student3' },
+  { _id: 4, username: 'test_student4', fullname: 'Test Student4' },
+  { _id: 5, username: 'test_student5', fullname: 'Test Student5' },
 ];
 
 let mock_response_type;

--- a/src/app/student/student.ts
+++ b/src/app/student/student.ts
@@ -2,13 +2,11 @@
 export class Student {
     _id: number;
     username: string;
-    course_ids: number[];
-    review_ids: number[];
+    fullname: string;
 
-    constructor(_id: number, username: string, course_ids: number[], review_ids: number[]) {
+    constructor(_id: number, username: string, fullname: string) {
         this._id = _id;
         this.username = username;
-        this.course_ids = course_ids;
-        this.review_ids = review_ids;
+        this.fullname = fullname;
     }
 }

--- a/src/app/teacher/teacher.service.spec.ts
+++ b/src/app/teacher/teacher.service.spec.ts
@@ -6,11 +6,11 @@ import { TeacherService } from './teacher.service';
 import { Teacher } from './teacher';
 
 export const TEACHERS: Teacher[] = [
-  { _id: 1, username: 'testuser1', course_ids: [1, 2, 3], review_ids: [1, 2, 3], student_ids: [1, 2, 3] },
-  { _id: 2, username: 'testuser2', course_ids: [6, 4, 15], review_ids: [4, 5, 6], student_ids: [1, 2, 3] },
-  { _id: 3, username: 'testuser3', course_ids: [5, 14, 13], review_ids: [7, 8, 9], student_ids: [1, 2, 3] },
-  { _id: 4, username: 'testuser4', course_ids: [12, 8, 7], review_ids: [10, 11, 12], student_ids: [1, 2, 3] },
-  { _id: 5, username: 'testuser5', course_ids: [10, 9, 11], review_ids: [13, 14, 15], student_ids: [1, 2, 3] },
+  { _id: 1, username: 'test_teacher1', fullname: 'Test Teacher1' },
+  { _id: 2, username: 'test_teacher2', fullname: 'Test Teacher2' },
+  { _id: 3, username: 'test_teacher3', fullname: 'Test Teacher3' },
+  { _id: 4, username: 'test_teacher4', fullname: 'Test Teacher4' },
+  { _id: 5, username: 'test_teacher5', fullname: 'Test Teacher5' },
 ];
 
 let mock_response_type;

--- a/src/app/teacher/teacher.ts
+++ b/src/app/teacher/teacher.ts
@@ -2,15 +2,11 @@
 export class Teacher {
     _id: number;
     username: string;
-    course_ids: number[];
-    review_ids: number[];
-    student_ids: number[];
+    fullname: string;
 
-    constructor(_id: number, username: string, course_ids: number[], review_ids: number[], student_ids: number[]) {
+    constructor(_id: number, username: string, fullname: string) {
         this._id = _id;
         this.username = username;
-        this.course_ids = course_ids;
-        this.review_ids = review_ids;
-        this.student_ids = student_ids;
+        this.fullname = fullname;
     }
 }


### PR DESCRIPTION
Fixes #66 .

Changes made in this pull request:
- Change `classes` to `courses`
  - `class` is a keyword in ts, so making a `class Class` doesn't quite work
- Update objects to only include only class properties
  - these changes have been applied to the mongo collections as well
- Update mock data in unit tests
